### PR TITLE
Support direct URLs for registration requests

### DIFF
--- a/datameta/static/js/admin.js
+++ b/datameta/static/js/admin.js
@@ -39,7 +39,6 @@ DataMeta.admin.answer_request = function(accept, form) {
         group_id: fdata.get("group_id") == -1 ? null :fdata.get("group_id"),
         fullname: fdata.get("fullname")
     });
-    console.log(json_body);
     fetch('/api/admin/request',
         {
             method: 'put',
@@ -73,14 +72,12 @@ DataMeta.admin.reload_requests = function(requests, groups) {
     accordion.querySelectorAll(".accordion-item").forEach(e => e.remove());
 
     // Re-generate them
-    console.log("requests = ", requests)
     if (requests.length==0) {
         document.getElementById("req_title").innerHTML = "No pending Account Requests";
     } else {
         document.getElementById("req_title").innerHTML = "Pending Account Requests";
     }
     requests.forEach(function(request) {
-        console.log(request);
         var template = document.getElementById("template_request");
         var clone = template.content.firstElementChild.cloneNode(true);
         var button = clone.querySelector("#acc_toggle");
@@ -154,6 +151,26 @@ DataMeta.admin.reload_requests = function(requests, groups) {
     });
 }
 
+
+DataMeta.admin.subnav = function() {
+    // Handle registration request preselection
+    var showreq = DataMeta.uilocal.showreq;
+    DataMeta.uilocal.showreq = null;
+    if (showreq != null) {
+        var admintabs = document.getElementById('admintabs');
+        // de-select all tabs
+        admintabs.querySelectorAll(".nav-link").forEach(elem => elem.classList.remove("active"))
+        admintabs.querySelectorAll(".tab-pane").forEach(elem => elem.classList.remove("show", "active"))
+        // account request tab
+        admintabs.querySelector("a[data-bs-target='#nav-requests']").classList.add("active");
+        admintabs.querySelector("#nav-requests").classList.add("active", "show");
+        // open the accordeon
+        document.getElementById("acc_toggle_"+showreq).classList.remove("collapsed");
+        document.getElementById("acc_collapse_"+showreq).classList.add("show");
+        document.getElementById("acc_collapse_"+showreq).scrollIntoView({behavior: "smooth", block: "end"});
+    }
+}
+
 /**
  * Reloads the admin view by making an API request and calling the individual
  * update functions for the individual tabs
@@ -166,6 +183,7 @@ DataMeta.admin.reload = function() {
             .then(response => response.json())
             .then(function (json) {
                 DataMeta.admin.reload_requests(json.reg_requests, json.groups);
+                DataMeta.admin.subnav();
             })
             .catch((error) => {
                 console.log(error);

--- a/datameta/templates/admin.pt
+++ b/datameta/templates/admin.pt
@@ -1,7 +1,8 @@
 <div metal:use-macro="load: layout.pt">
     <div metal:fill-slot="content" class="row">
+    <script>DataMeta.uilocal['showreq'] = ${showreq};</script>
         <div class="col-12 ">
-            <div class="card">
+            <div id="admintabs" class="card">
                 <div class="card-header">
                     <ul class="nav nav-tabs card-header-tabs">
                         <li class="nav-item">

--- a/datameta/templates/layout.pt
+++ b/datameta/templates/layout.pt
@@ -82,6 +82,7 @@
         </script>
         <script>
             window.DataMeta = {};
+            DataMeta.uilocal = {};
             DataMeta.toolTips = [];
             DataMeta.popoverList = [];
         </script>

--- a/datameta/views/admin.py
+++ b/datameta/views/admin.py
@@ -33,7 +33,14 @@ log = logging.getLogger(__name__)
 @view_config(route_name='admin', renderer='../templates/admin.pt')
 def v_admin(request):
     security.revalidate_admin(request)
-    return {}
+    showreq='null'
+    try:
+        showreq=int(request.GET.get("showreq"))
+    except:
+        pass
+    return {
+            'showreq' : showreq
+            }
 
 @view_config(route_name='admin_put_request', renderer='json', request_method='PUT')
 def v_admin_put_request(request):

--- a/datameta/views/home.py
+++ b/datameta/views/home.py
@@ -28,5 +28,5 @@ from .. import security
 
 @view_config(route_name='home', renderer='../templates/home.pt')
 def my_view(request):
-    security.revalidate_user(request)
+    security.revalidate_user_or_login(request)
     return {}

--- a/datameta/views/view.py
+++ b/datameta/views/view.py
@@ -28,5 +28,5 @@ from .. import security
 
 @view_config(route_name='view', renderer='../templates/view.pt')
 def my_view(request):
-    security.revalidate_user(request)
+    security.revalidate_user_or_login(request)
     return {}


### PR DESCRIPTION
In preparation for sending out emails to admins when someone registered, this patch adds a GET feature to the admin endpoint.

    /admin?showreq={id}

will open the admin page, switch to the "Account Request" tab and open the accordion at the referenced account request.