### PR TITLE
move database init to install

### DIFF
--- a/docker/dev_install
+++ b/docker/dev_install
@@ -1,8 +1,27 @@
 #!/bin/bash
 # for use in the vscode devcontainer environment
+cd /workspace
 
 echo -e ">>> Installing npm dependencies:\n\n"
 npm install --prefix /workspace/datameta/static/
 
 echo -e "\n\n>>> Installing python dependencies\n\n>>> this might take some time:\n\n"
 pip install -v -e "/workspace/.[testing]"
+
+echo -e "\n\n>>> Replace environment variables with their respective values:\n\n"
+mkdir -p /tmp/datameta
+envsubst < "/workspace/conf/docker_development.ini" > /tmp/datameta/config.ini
+
+echo -e "\n\n>>> Initialize database if required:\n\n"
+set -x
+set -e
+# Try to connect to the database, fail startup otherwise
+psql -c '\dt' "$SQLALCHEMY_URL"
+
+# Check if the database has been initialized and if not initialize it
+if ! psql -c '\dt' "$SQLALCHEMY_URL" | fgrep alembic &>/dev/null; then
+	alembic -c /tmp/datameta/config.ini upgrade head
+	alembic -c /tmp/datameta/config.ini revision --autogenerate -m "init"
+	alembic -c /tmp/datameta/config.ini upgrade head
+	initialize_datameta_db /tmp/datameta/config.ini
+fi

--- a/docker/dev_launcher
+++ b/docker/dev_launcher
@@ -22,29 +22,7 @@
 # SOFTWARE.
 
 # for use in the vscode devcontainer environment
-
 set -x
-set -e
 
-# Replace environment variables with their respective values
-TMP_DIR=$(mktemp -d)
-echo "Executing in temp dir: ${TMP_DIR}"
-cd "${TMP_DIR}"
-cp -rT /workspace "${TMP_DIR}"
+pserve --reload /tmp/datameta/config.ini
 
-# Replace environment variables with their respective values
-envsubst < "/workspace/conf/docker_development.ini" > "${TMP_DIR}/config.ini"
-
-# Try to connect to the database, fail startup otherwise
-psql -c '\dt' "$SQLALCHEMY_URL"
-
-# Check if the database has been initialized and if not initialize it
-if ! psql -c '\dt' "$SQLALCHEMY_URL" | fgrep alembic &>/dev/null; then
-	alembic -c "${TMP_DIR}/config.ini" upgrade head
-	alembic -c "${TMP_DIR}/config.ini" revision --autogenerate -m "init"
-	alembic -c "${TMP_DIR}/config.ini" upgrade head
-	initialize_datameta_db "${TMP_DIR}/config.ini"
-fi
-
-# Launch the application
-pserve --reload "${TMP_DIR}/config.ini"


### PR DESCRIPTION
Hi @lkuchenb,

I run into problems when repeatingly deploying the dev_launcher script. Then I realized that we planned to get rid of copying the workspace for deployment either way. I moved the database init to the dev_install and let alembic directly play in the workspace and it seems to work fine.

Could you please check that and merge it if OK?