### PR TITLE
allow nullable metadata record values

### DIFF
--- a/datameta/api/metadatasets.py
+++ b/datameta/api/metadatasets.py
@@ -50,10 +50,17 @@ class MetaDataSetResponse:
 
 
 def render_record_values(mdatum:Dict[str, models.MetaDatum], record:dict) -> dict:
-    """Renders values of a metadataset record"""
+    """Renders values of a metadataset record. Please note: the record should already have passed validation."""
     record_rendered = record.copy()
-    for field in record_rendered:
-        if mdatum[field].datetimefmt:
+    for field in mdatum:
+        if not field in record_rendered.keys():
+            # if field is not contained in record, add it as None to the record:
+            record_rendered[field] = None
+            continue
+        elif field is None:
+            continue
+        elif mdatum[field].datetimefmt:
+            # if MetaDatum is a datetime field, render the value in isoformat
             record_rendered[field] = datetime.datetime.strptime(
                     record_rendered[field], 
                     mdatum[field].datetimefmt

--- a/datameta/api/openapi.yaml
+++ b/datameta/api/openapi.yaml
@@ -232,6 +232,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MetaDataSetResponse"
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
         '400':
           $ref: '#/components/responses/ValidationError'
         '500':

--- a/datameta/linting.py
+++ b/datameta/linting.py
@@ -126,14 +126,7 @@ def validate_metadataset_record(
     mdats = { mdat.name: mdat for mdat in mdats_query }
     
     for name, value in record.items():
-        # check if values are of allowed types:
-        # (all values will be stringified later)
-        if not isinstance(value, str):
-            errors.append({
-                "message": "field value must be a string.",
-                "field": name
-            })
-
+        
         # check if the name appears in the metadatum list
         if not name in mdats.keys():
             errors.append({
@@ -145,6 +138,25 @@ def validate_metadataset_record(
             })
             continue
         mdat = mdats[name]
+        
+        # if value is none but mandatory,
+        # throw and error, moreover, if the value is none
+        # but not mandatory skip the following checks:
+        if value is None:
+            if mdat.mandatory:
+                errors.append({
+                    "message": "field value was null, but the field is mandatory",
+                    "field": name
+                })
+            continue
+
+        # check if values are of allowed types:
+        # (all values will be stringified later)
+        if not isinstance(value, str):
+            errors.append({
+                "message": "field value must be a string.",
+                "field": name
+            })
 
         # Check if the regexp pattern matches
         if mdat.regexp and re.match(mdat.regexp, value) is None:

--- a/datameta/linting.py
+++ b/datameta/linting.py
@@ -125,20 +125,20 @@ def validate_metadataset_record(
     mdats_query = db.query(MetaDatum).order_by(MetaDatum.order).all()
     mdats = { mdat.name: mdat for mdat in mdats_query }
     
-    for name, value in record.items():
+    for name, mdat in mdats.items():
         
-        # check if the name appears in the metadatum list
-        if not name in mdats.keys():
-            errors.append({
-                "message": (
-                    f"field with name \"name\""
-                    "is not allowed"
-                ),
-                "field": name
-            })
+        # check if mdat is present in record dict
+        # if not and mdat is mandatory, throw an error:
+        if name not in record:
+            if mdat.mandatory:
+                errors.append({
+                    "message": "field was not specified but is mandatory",
+                    "field": name
+                })
             continue
-        mdat = mdats[name]
         
+        value = record[name]
+
         # if value is none but mandatory,
         # throw and error, moreover, if the value is none
         # but not mandatory skip the following checks:
@@ -184,14 +184,16 @@ def validate_metadataset_record(
                 })
                 continue   
     
-    # Check if all mandatory fields exist:
-    mdats_mandatory = {name for name, mdat in mdats.items() if mdat.mandatory}
-    rec_names = set(record.keys())
-    if not mdats_mandatory.issubset(rec_names):
-        errors.append({
-            "message": "The record is missing mandatory fields.",
-        })
-    
+    # check if any of the record fields has no corresponding MetaDatum object:
+    mdats_set = set(mdats.keys())
+    record_set = set(record.keys())
+    if not record_set.issubset(mdats_set):
+        for field in record_set.difference(mdats_set):
+            errors.append({
+                "message": "The field was not expected.",
+                "field": field
+            })
+            
     # return the error messages
     # or raise validation errors
     if return_err_message:


### PR DESCRIPTION
Users are allowed to specify null as values for MetaDatumRecords as long as these records are not mandatory.
These null values will not be ignored but stored in the database.