### PR TITLE
Document GET:/users/{id}/keys -> 403 Forbidden

### DIFF
--- a/datameta/api/openapi.yaml
+++ b/datameta/api/openapi.yaml
@@ -160,8 +160,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiKeyList"
-        "401":
+        '401':
           description: Unauthorized
+        '403':
+          description: Forbidden
         '400':
           $ref: '#/components/responses/ValidationError'
         '500':


### PR DESCRIPTION
Endpoint returns `403 Forbidden` when the user is not authenticated as `{id}`. This was undocumented.