### PR TITLE
Prevent metadata table wrap, enable horizontal scrolling

### DIFF
--- a/datameta/static/js/submit.js
+++ b/datameta/static/js/submit.js
@@ -286,6 +286,7 @@ DataMeta.submit.rebuildMetadataTable = function(keys, fileKeys, metadata) {
     $("#table_metadata").DataTable({
         drawCallback: function(settings) { DataMeta.submit.registerDynamicEvents(); },
         destroy: true,
+        scrollX: true,
         data: metadata,
         sDom: "<'row'<'span8'l><'span8'f>r>t", // Hide footer
         order: [[2,"asc"]],

--- a/datameta/templates/submit.pt
+++ b/datameta/templates/submit.pt
@@ -46,7 +46,7 @@
                     <a id="commit_btn" class="btn btn-success w-100" href="#" style="display:none">Commit</a>
                 </div>
             </div>
-            <table id="table_metadata" class="table table-sm table-hover" style="width:100%">
+            <table id="table_metadata" class="table table-sm table-hover text-nowrap" style="width:100%">
             </table>
             <span class="me-2"><i class="bi bi-check-circle-fill text-success"></i> Ready to commit</span>
             <span class="me-2"><i class="bi bi-exclamation-diamond-fill text-warning"></i> Faulty record</span>


### PR DESCRIPTION
The metadata table breaks when there is a higher number of metadata. This patch enables vertical scrolling if necessary and prevents linebreaks within table cells.