### PR TITLE
empty filenames will now return http 400 (#149)

### DIFF
--- a/datameta/api/files.py
+++ b/datameta/api/files.py
@@ -172,9 +172,7 @@ def update_file(request: Request) -> HTTPOk:
         raise HTTPNotFound(json=None) # 404
     if db_file.user_id != auth_user.id:
         raise HTTPForbidden(json=None) # 403
-    if not db_file.name:
-        raise errors.get_validation_error(["File names cannot be empty."])
-
+    
     # We only allow modifications before the file is committed (uploaded)
     if db_file.content_uploaded:
         raise errors.get_not_modifiable_error() # 403
@@ -183,7 +181,10 @@ def update_file(request: Request) -> HTTPOk:
     if 'checksum' in request.openapi_validated.body:
         db_file.checksum  = request.openapi_validated.body['checksum']
     if 'name' in request.openapi_validated.body:
-        db_file.name      = request.openapi_validated.body['name']
+        updated_name      = request.openapi_validated.body['name']
+        if not updated_name:
+            raise errors.get_validation_error(["File names cannot be empty."])
+        db_file.name = updated_name
 
     # Freeze the file
     if request.openapi_validated.body.get('contentUploaded'):

--- a/datameta/api/files.py
+++ b/datameta/api/files.py
@@ -65,6 +65,9 @@ def post(request: Request) -> FileUploadResponse:
     req_name = request.openapi_validated.body["name"]
     req_checksum = request.openapi_validated.body["checksum"]
 
+    if not req_name:
+        raise errors.get_validation_error(message=["File names cannot be empty."])
+
     # Create the corresponding database object
     db_file = models.File(
             site_id           = siteid.generate(request, models.File),
@@ -169,6 +172,8 @@ def update_file(request: Request) -> HTTPOk:
         raise HTTPNotFound(json=None) # 404
     if db_file.user_id != auth_user.id:
         raise HTTPForbidden(json=None) # 403
+    if not db_file.name:
+        raise errors.get_validation_error(["File names cannot be empty."])
 
     # We only allow modifications before the file is committed (uploaded)
     if db_file.content_uploaded:

--- a/datameta/api/files.py
+++ b/datameta/api/files.py
@@ -172,7 +172,6 @@ def update_file(request: Request) -> HTTPOk:
         raise HTTPNotFound(json=None) # 404
     if db_file.user_id != auth_user.id:
         raise HTTPForbidden(json=None) # 403
-    
     # We only allow modifications before the file is committed (uploaded)
     if db_file.content_uploaded:
         raise errors.get_not_modifiable_error() # 403

--- a/datameta/api/metadata.py
+++ b/datameta/api/metadata.py
@@ -88,8 +88,6 @@ def put(request:Request):
     target_metadatum = resource_by_id(db, MetaDatum, metadata_id)
 
     body = request.openapi_validated.body
-    if body["isFile"] and not body["name"]:
-        raise get_validation_error(messages=["File names cannot be empty."])
 
     target_metadatum.name                = body["name"]
     target_metadatum.short_description   = body["regexDescription"] if body["regexDescription"] else None

--- a/datameta/api/metadata.py
+++ b/datameta/api/metadata.py
@@ -21,7 +21,6 @@ from ..models import MetaDatum
 from .. import resource, security, siteid
 from ..resource import resource_by_id, get_identifier
 from pyramid.httpexceptions import HTTPNoContent, HTTPForbidden
-from ..errors import get_validation_error
 
 @dataclass
 class MetaDataResponseElement(DataHolderBase):

--- a/datameta/api/metadata.py
+++ b/datameta/api/metadata.py
@@ -21,6 +21,7 @@ from ..models import MetaDatum
 from .. import resource, security, siteid
 from ..resource import resource_by_id, get_identifier
 from pyramid.httpexceptions import HTTPNoContent, HTTPForbidden
+from ..errors import get_validation_error
 
 @dataclass
 class MetaDataResponseElement(DataHolderBase):
@@ -87,6 +88,8 @@ def put(request:Request):
     target_metadatum = resource_by_id(db, MetaDatum, metadata_id)
 
     body = request.openapi_validated.body
+    if body["isFile"] and not body["name"]:
+        raise get_validation_error(messages=["File names cannot be empty."])
 
     target_metadatum.name                = body["name"]
     target_metadatum.short_description   = body["regexDescription"] if body["regexDescription"] else None

--- a/datameta/linting.py
+++ b/datameta/linting.py
@@ -30,13 +30,19 @@ def validate_metadataset_record(
                         # already in isoformat) 
 ):
     """Validate single metadataset in isolation"""
-    errors = [] # list of error
+    errors = [] # list of errors
                 # empty means success
 
     # get all metadatum fields:
     db = request.dbsession
     mdats_query = db.query(MetaDatum).order_by(MetaDatum.order).all()
     mdats = { mdat.name: mdat for mdat in mdats_query }
+
+    if mdats.get("isFile") and not mdats.get("name"):
+        errors.append({
+            "message": "file names cannot be empty.",
+            "field": "name"
+        })
 
     for name, mdat in mdats.items():
 
@@ -111,7 +117,7 @@ def validate_metadataset_record(
     # or raise validation errors
     if return_err_message:
         return errors
-    elif len(errors) > 0:
+    elif errors:
         messages = [err["message"] for err in errors]
         fields = [
             err["field"] if "field" in err else None


### PR DESCRIPTION
These endpoints should now yield validation errors 400 when empty file names are submitted:

* `POST:/files`
* `PUT:/files/{id}`
* `POST:/metadatasets`

