### PR TITLE
rename /users/self to /whoami

### DIFF
--- a/datameta/api/__init__.py
+++ b/datameta/api/__init__.py
@@ -43,7 +43,7 @@ def includeme(config: Configurator) -> None:
     config.add_route("apikeys_id", base_url + "/keys/{id}")
     config.add_route("user_id_keys", base_url + "/users/{id}/keys")
     config.add_route("SetUserPassword", base_url + "/users/{id}/password")
-    config.add_route("user_self", base_url + "/users/self")
+    config.add_route("whoami", base_url + "/whoami")
     config.add_route("user_id", base_url + "/users/{id}")
     config.add_route("metadata", base_url + "/metadata")
     config.add_route("metadata_id", base_url + "/metadata/{id}")

--- a/datameta/api/openapi.yaml
+++ b/datameta/api/openapi.yaml
@@ -15,7 +15,7 @@
 openapi: 3.0.0
 info:
   description: DataMeta
-  version: 0.10.0
+  version: 0.11.0
   title: DataMeta
 
 servers:
@@ -95,12 +95,13 @@ paths:
         '500':
           description: Internal Server Error
 
-  /users/self:
+  /whoami:
     get:
-      summary: Return relevant information about the user
+      summary: "[Not RESTful]: Returns information about the authenticated user"
       description: >-
         Returns the id's, name, groupAdmin, siteAdmin, 
         email and groupName attributes for the logged in user.
+        [Attention this endpoint is not RESTful, the result should not be cached.]
       tags:
         - Authentication and Users
       operationId: GetUserInformation

--- a/datameta/api/users.py
+++ b/datameta/api/users.py
@@ -42,12 +42,12 @@ class UserResponseElement(DataHolderBase):
     group: dict
 
 @view_config(
-    route_name="user_self", 
+    route_name="whoami", 
     renderer='json', 
     request_method="GET", 
     openapi=True
 )
-def get_self(request: Request) -> UserResponseElement:
+def get_whoami(request: Request) -> UserResponseElement:
     
     auth_user = security.revalidate_user(request)
 

--- a/datameta/static/js/datameta.js
+++ b/datameta/static/js/datameta.js
@@ -142,7 +142,7 @@ DataMeta.getLargeMD5 = function(file, cbProgress) {
  * Gets information about the logged in user: ids, name, email, admin status and group
  */
 window.addEventListener("load", function() {
-    fetch(DataMeta.api('users/self'),
+    fetch(DataMeta.api('whoami'),
     {
         method: 'GET'
     })


### PR DESCRIPTION
Renames the `GET /users/self` into `GET /whoami` to better reflect that this endpoint is not RESTful. Added OpenAPI version bump.

I hope that is OK for you @MoritzHahn1337 :)
