### PR TITLE
Add GH action version check

### DIFF
--- a/.github/workflows/version_checks.yml
+++ b/.github/workflows/version_checks.yml
@@ -1,0 +1,48 @@
+name: Run versioning checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited, reopened]
+    branches: [ main, develop ]
+
+jobs:
+  version_checks:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: "pr"
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.base_ref }}
+        path: "base"
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9.x'
+    - name: Install Dependencies
+      run: pip install pyyaml
+    - name: Verify Package Version
+      working-directory: "pr"
+      run: |
+        pkg_ver="$(python setup.py -V)"
+        echo "Package version is $pkg_ver"
+        if ! git rev-parse --verify "refs/tags/v$pkg_ver" &>/dev/null; then
+          echo "[OK] Package version was not yet tagged"
+        else
+          echo "[ERR] The current package version has been tagged previously. The first merge after a release must bump the package version." >&2
+          exit 1
+        fi
+    - name: Verify OpenAPI version
+      run: |
+        if ! diff -wB pr/datameta/api/openapi.yaml base/datameta/api/openapi.yaml; then
+          echo "[INFO] OpenAPI specification has changes"
+          if [ "$(./pr/utils/openapi_version.py < pr/datameta/api/openapi.yaml)" == "$(./pr/utils/openapi_version.py < base/datameta/api/openapi.yaml)" ]; then
+            echo "[ERR] OpenAPI specification needs API version bump" >&2
+            exit 1
+          else
+            echo "[OK] OpenAPI specification contains new API version"
+          fi
+        else
+          echo "[OK] OpenAPI specification unchanged"
+        fi

--- a/utils/openapi_version.py
+++ b/utils/openapi_version.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright 2021 Universität Tübingen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import yaml
+import sys
+
+parser = argparse.ArgumentParser("Extracts the API version from an OpenAPI YAML file")
+parser.add_argument("-i", "--input", type=argparse.FileType("r"), help="Input YAML file (default: stdin)", default=sys.stdin)
+
+args = parser.parse_args()
+
+print(yaml.safe_load(args.input)["info"]["version"])


### PR DESCRIPTION
Add two basic version checks that
* Make sure we bump the API version if changes to the specification are made
* We bump the package version after a release