### PR TITLE
Redesign Footer, refactor `GET:/api`, add `GET:/api/server`

### DIFF
--- a/datameta/__init__.py
+++ b/datameta/__init__.py
@@ -17,6 +17,10 @@ from pyramid_beaker import session_factory_from_settings
 import os
 from . import api
 
+from pkg_resources import get_distribution
+
+__version__ = get_distribution('datameta').version
+
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
     """

--- a/datameta/api/__init__.py
+++ b/datameta/api/__init__.py
@@ -22,6 +22,8 @@ from dataclasses_json import dataclass_json, LetterCase
 import os
 import yaml
 
+import datameta
+
 openapi_spec_path = os.path.join(os.path.dirname(__file__), "openapi.yaml")
 # read base url from openapi.yaml:
 with open(openapi_spec_path, "r") as spec_file:
@@ -39,6 +41,7 @@ class DataHolderBase:
 def includeme(config: Configurator) -> None:
     """Pyramid knob."""
     config.add_route("api", "/api")
+    config.add_route("server", base_url + "/server")
     config.add_route("apikeys", base_url + "/keys")
     config.add_route("apikeys_id", base_url + "/keys/{id}")
     config.add_route("user_id_keys", base_url + "/users/{id}/keys")
@@ -70,4 +73,4 @@ def includeme(config: Configurator) -> None:
     request_method="GET",
 )
 def get(request: Request):
-    return HTTPFound(base_url, json_body = {'version' : api_version})
+    return HTTPFound(base_url)

--- a/datameta/api/openapi.yaml
+++ b/datameta/api/openapi.yaml
@@ -15,7 +15,7 @@
 openapi: 3.0.0
 info:
   description: DataMeta
-  version: 0.12.0
+  version: 0.13.0
   title: DataMeta
 
 servers:
@@ -848,6 +848,23 @@ paths:
         '500':
           description: Internal Server Error
 
+  /server:
+    get:
+      summary: Get DataMeta server information
+      description: Get information about the DataMeta server serving this API
+      tags:
+        - Server
+      operationId: GetServerInfo
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerInfoResponse"
+        "500":
+          description: Internal Server Error
+
   /appsettings/{id}:
     put:
       summary: Update a specific appsetting. This is an administrative Endpoint that is not accessible for regular users.
@@ -1285,6 +1302,18 @@ components:
           - isFile
           - isSubmissionUnique
           - isSiteUnique
+      additionalProperties: false
+
+    ServerInfoResponse:
+      type: object
+      properties:
+        apiVersion:
+          type: string
+        datametaVersion:
+          type: string
+      required:
+        - apiVersion
+        - datametaVersion
       additionalProperties: false
 
     AppSettingsResponse:

--- a/datameta/api/server.py
+++ b/datameta/api/server.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Universität Tübingen, DKFZ and EMBL for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyramid.view import view_config
+from pyramid.request import Request
+
+from dataclasses import dataclass
+from . import DataHolderBase, api_version
+
+import datameta
+
+@dataclass
+class ServerInfoResponse(DataHolderBase):
+    api_version: str
+    datameta_version: str
+
+@view_config(
+    route_name="server",
+    renderer='json', 
+    request_method="GET", 
+    openapi=True
+)
+def get(request: Request) -> ServerInfoResponse:
+    return ServerInfoResponse(
+            api_version        = api_version,
+            datameta_version   = datameta.__version__
+    )

--- a/datameta/static/js/datameta.js
+++ b/datameta/static/js/datameta.js
@@ -159,8 +159,17 @@ window.addEventListener("load", function() {
     .then(response => response.json())
     .then(function (json) {
         DataMeta.user = json;
-        var event = new Event('dmready')
-        window.dispatchEvent(event);
+        fetch(
+            DataMeta.api('server'),
+            { method: 'GET' }
+        ).then(function(response) {
+            return response.json();
+        }).then(function (json_api) {
+            DataMeta.version       = json_api.datametaVersion;
+            DataMeta.apiVersion   = json_api.apiVersion;
+            var event              = new Event('dmready')
+            window.dispatchEvent(event);
+        })
     })
     .catch((error) => {
         console.log(error);

--- a/datameta/templates/layout.pt
+++ b/datameta/templates/layout.pt
@@ -85,8 +85,10 @@
 
             // Takes name and organisation from API call and puts them in the footer, enables the admin interface button, if the user is a site_admin
             window.addEventListener("dmready", function() {
-                var nameOrgString = "Logged in as: " + DataMeta.user.name + " ("+ DataMeta.user.group.name + ")";
+                var nameOrgString = DataMeta.user.name + " ("+ DataMeta.user.group.name + ")";
                 document.getElementById("name_org").innerHTML = nameOrgString;
+                document.getElementById("datameta_version").innerHTML = DataMeta.version;
+                document.getElementById("datameta_api_version").innerHTML = DataMeta.apiVersion;
                 if(DataMeta.user.siteAdmin || DataMeta.user.groupAdmin) {
                     document.getElementById("admin_view_button").style.display = "";
                 }
@@ -114,16 +116,25 @@
             </div>
         </main>
 
-        <footer class="fixed-bottom footer mt-auto py-3 bg-light">
-            <div class="container position-relative">
-                <span class="text-muted">&copy; 2021 DataMeta</span><span tal:condition="request.registry.settings.get('datameta.demo_mode') in [True, 'true', 'True']"> (DEMO MODE)</span>
-                <span id="name_org" class="ms-2"></span>
-                    <div class="form-check form-switch position-absolute top-50 end-0 translate-middle">
-                      <input class="form-check-input" type="checkbox" name="flexSwitchWidescreen" id="flexSwitchWidescreen" onClick="toggle_widescreen()">
-                      <label class="form-check-label" for="flexSwitchWidescreen">
-                        Widescreen
-                      </label>
-                    </div>
+        <footer class="fixed-bottom footer mt-auto pt-2 bg-light">
+            <div class="container d-flex justify-content-between">
+                <div>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
+                        <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"/>
+                        <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z"/>
+                    </svg>
+                    <span id="name_org" class="ms-1" style="vertical-align:middle"></span>
+                </div>
+                <div class="form-check form-switch ">
+                    <input class="form-check-input" type="checkbox" name="flexSwitchWidescreen" id="flexSwitchWidescreen" onClick="toggle_widescreen()">
+                    <label class="form-check-label" for="flexSwitchWidescreen">Widescreen</label>
+                </div>
+            </div>
+            <div class="container mb-1" style="font-size:7pt">
+                <span>DataMeta Version </span><span id="datameta_version"></span><span> - API Version </span><span id="datameta_api_version"></span>
+                <span class="text-danger" tal:condition="request.registry.settings.get('datameta.demo_mode') in [True, 'true', 'True']">
+                    - [DEMO MODE]
+                </span>
             </div>
 
         </footer>


### PR DESCRIPTION

<img width="1294" alt="Screen Shot 2021-04-21 at 14 54 02" src="https://user-images.githubusercontent.com/5948880/115557298-dcaa6e00-a2b1-11eb-9dc8-bc1887cfff3d.png">

* Redesign footer
* Add backend and API version to the footer
* Add `GET:/server` endpoint to return versions, apparently returning a body with a `301` isn't quite conform with standards, at least JS `fetch()` isn't able to access the body of a `301` response. Thus the body of `/api` was removed.