### PR TITLE
Store submission datetimes as UTC times

### DIFF
--- a/datameta/api/submissions.py
+++ b/datameta/api/submissions.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
+from datetime import datetime, timezone
 from dataclasses import dataclass
 from collections import Counter, defaultdict
 from pyramid.view import view_config
@@ -275,7 +275,7 @@ def post(request: Request) -> SubmissionResponse:
     submission = Submission(
             site_id = siteid.generate(request, Submission),
             label = label,
-            date = datetime.datetime.now(),
+            date = datetime.now(tz=timezone.utc),
             metadatasets = list(db_msets.values()),
             group_id = auth_user.group.id
             )

--- a/datameta/static/js/view.js
+++ b/datameta/static/js/view.js
@@ -24,7 +24,6 @@ DataMeta.view.buildColumns = function(mdata) {
             title : mdatum.serviceId === null ? mdatum.name : '<i class="bi bi-cpu"></i> '+mdatum.name,
             data : null,
             render : function(mdataset, type, row, meta) {
-                console.log(mdataset)
                 // We don't have access
                 if (!(mdatum.name in mdataset.record)) return '<i class="bi bi-lock-fill text-danger"></i>';
                 // Special case NULL and service metadatum with access but not run yet
@@ -56,17 +55,22 @@ DataMeta.view.initTable = function() {
     var mdata = json;
 
     var columns = [
-        { title: "Submission", data: null, className: "id_col", render: function(data) {
+        { title: '<i class="bi bi-house-door"></i> Submission', data: null, className: "id_col", render: function(data) {
             var label = data.submissionLabel ? data.submissionLabel : '<span class="text-black-50"><i>empty</i></span>';
             return '<div> <div class="large-super">' + label + '</div><div class="text-accent small-sub">' + data.submissionId.site + '</div></div>'
         }},
-        { title: "User", data: null, className: "id_col", render: data =>
+        { title: '<i class="bi bi-house-door"></i> Submission Time', data: null, className: "id_col", render: function(data) {
+            var d = moment(new Date(data.submissionDatetime));
+            return '<div> <div class="large-super">' + d.format('YYYY-MM-DD HH:mm:ss') +
+                '</div><div class="text-accent small-sub">' + 'GMT' + d.format('ZZ') + '</div></div>'
+        }},
+        { title: '<i class="bi bi-house-door"></i> User', data: null, className: "id_col", render: data =>
             '<div> <div class="large-super">'+data.userName+'</div><div class="text-accent small-sub">'+data.userId.site+'</div></div>'
         },
-        { title: "Group", data: null, className: "id_col", render: data =>
+        { title: '<i class="bi bi-house-door"></i> Group', data: null, className: "id_col", render: data =>
             '<div> <div class="large-super">'+data.groupName+'</div><div class="text-accent small-sub">'+data.groupId.site+'</div></div>'
         },
-        { title: "Metadataset", data: "id.site", className: "id_col", render: data => '<span class="text-accent">' + data + '</span>'}
+        { title: '<i class="bi bi-house-door"></i> ID', data: "id.site", className: "id_col", render: data => '<span class="text-accent">' + data + '</span>'}
       ].concat(DataMeta.view.buildColumns(mdata))
 
     // Build table based on field names

--- a/datameta/static/js/view.js
+++ b/datameta/static/js/view.js
@@ -27,7 +27,10 @@ DataMeta.view.buildColumns = function(mdata) {
                 // We don't have access
                 if (!(mdatum.name in mdataset.record)) return '<i class="bi bi-lock-fill text-danger"></i>';
                 // Special case NULL and service metadatum with access but not run yet
-                if (mdatum.name in mdataset.serviceExecutions && mdataset.serviceExecutions[mdatum.name]===null) return '<span class="text-black-50"><i class="bi bi-hourglass-split"></i> <i>pending</i></span>';
+                if (mdataset.serviceExecutions !== null
+                    && mdatum.name in mdataset.serviceExecutions
+                    && mdataset.serviceExecutions[mdatum.name]===null)
+                    return '<span class="text-black-50"><i class="bi bi-hourglass-split"></i> <i>pending</i></span>';
                 // Special case NULL
                 if (mdataset.record[mdatum.name] === null) return '<span class="text-black-50"><i>empty</i></span>';
                 // Speical case file

--- a/datameta/static/package.json
+++ b/datameta/static/package.json
@@ -7,6 +7,7 @@
     "crypto-js": "^4.0.0",
     "datatables.net-fixedcolumns": "^3.3.2",
     "datatables.net-responsive": "^2.2.7",
-    "jquery": "^3.6.0"
+    "jquery": "^3.6.0",
+    "moment": "^2.29.1"
   }
 }

--- a/datameta/templates/view.pt
+++ b/datameta/templates/view.pt
@@ -28,6 +28,7 @@
     <script type="text/javascript" charset="utf8" src="${request.static_url('datameta:static/node_modules/jquery/dist/jquery.js')}"></script>
     <script type="text/javascript" charset="utf8" src="${request.static_url('datameta:static/js/jquery.dataTables.min.js')}"></script>
     <script type="text/javascript" charset="utf8" src="${request.static_url('datameta:static/js/dataTables.bootstrap5.min.js')}"></script>
+    <script type="text/javascript" charset="utf8" src="${request.static_url('datameta:static/node_modules/moment/min/moment.min.js')}"></script>
     <script type="text/javascript" charset="utf8" src="${request.static_url('datameta:static/js/view.js')}"></script>
     </metal:block>
 </div>


### PR DESCRIPTION
* The date/time of a submission is now stored in UTC
* The *View Data* view reports the submission time in local browser time indicating the display timezone
* Added the `moment` JS library for datetime formatting