### PR TITLE
Add NULL records when a new metadatum is defined

### DIFF
--- a/datameta/api/metadata.py
+++ b/datameta/api/metadata.py
@@ -17,7 +17,7 @@ from typing import Optional, List
 from pyramid.request import Request
 from pyramid.view import view_config
 from . import DataHolderBase
-from ..models import MetaDatum, User, Service
+from ..models import MetaDatum, User, Service, MetaDataSet, MetaDatumRecord
 from .. import resource, security
 from ..security import authz
 from ..resource import resource_by_id, get_identifier
@@ -194,6 +194,10 @@ def post(request: Request) -> MetaDataResponseElement:
     )
 
     db.add(metadatum)
+
+    # Add a NULL value for every metadataset
+    db.add_all(MetaDatumRecord(metadataset_id=mset_id, metadatum=metadatum) for (mset_id,) in db.query(MetaDataSet.id))
+
     db.flush()
 
     return MetaDataResponseElement(


### PR DESCRIPTION
This is a first step towards solving issue #413 which at least enables the creation of metadata without violating the database integrity