### PR TITLE
Pin pyramid_openapi3 to 0.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ requires = [
     'SQLAlchemy == 1.3.*',
     'transaction',
     'zope.sqlalchemy',
-    'pyramid_openapi3',
+    'pyramid_openapi3==0.11',
     'openapi-core<0.14',
     'pytest >= 3.7.4',
     'dataclasses-json==0.5.2',


### PR DESCRIPTION
0.12's dependencies are no longer compatible with Pyramid 2.0. Not sure if that's intentional, see https://github.com/Pylons/pyramid_openapi3/pull/133