### PR TITLE
Fixed group admin requests

### DIFF
--- a/datameta/api/ui/admin.py
+++ b/datameta/api/ui/admin.py
@@ -64,7 +64,11 @@ def v_admin_put_request(request):
 
     # Check if the requesting user is authorized. Both the request group as well as the
     # administratively selected group have to be the requesting user's group
-    if not req_user.site_admin and (reg_req.group_id != req_user.group_id.uuid or newuser_group_id != req_user.group_id.uuid):
+
+    # import pdb
+    # pdb.set_trace()
+
+    if not req_user.site_admin and (reg_req.group_id != req_user.group_id or newuser_group_id != str(req_user.group.uuid)):
         return HTTPUnauthorized()
 
     # Check if the specified group id is valid

--- a/datameta/api/ui/admin.py
+++ b/datameta/api/ui/admin.py
@@ -65,9 +65,6 @@ def v_admin_put_request(request):
     # Check if the requesting user is authorized. Both the request group as well as the
     # administratively selected group have to be the requesting user's group
 
-    # import pdb
-    # pdb.set_trace()
-
     if not req_user.site_admin and (reg_req.group_id != req_user.group_id or newuser_group_id != str(req_user.group.uuid)):
         return HTTPUnauthorized()
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ tests_require = [
 
 setup(
     name                   = 'datameta',
-    version                = '1.0.3',
+    version                = '1.0.4',
     description            = 'DataMeta - submission server for data and associated metadata',
     long_description       = README + '\n\n' + CHANGES,
     author                 = 'Leon Kuchenbecker',


### PR DESCRIPTION
This must have gotten lost in a merge somewhere.

Issue Report:

1. When clicking on the link, I get a 404 (instead of a login prompt; if I am logged in already, the link leads me to ‘User Management’
2. When trying to activate xxxxxx request (button “Save and Accept”), I get the message “An unknown error occurred”

Solution:

1a. The refferal is a 401 by design, if you are not logged in. 
1b. If logged in, I always get reffered to Account Requests, so can't reproduce the problem
2. The original fix for this problem must have gotten lost somewhere in a merge. 
