### PR TITLE
Fix GET:/users/{id} response

### DIFF
--- a/datameta/api/openapi.yaml
+++ b/datameta/api/openapi.yaml
@@ -15,7 +15,7 @@
 openapi: 3.0.0
 info:
   description: DataMeta
-  version: 1.3.0
+  version: 1.4.0
   title: DataMeta
 
 servers:
@@ -1771,17 +1771,12 @@ components:
         email:
           type: string
           nullable: true
-        group:
-          type: object
-          properties:
-            id:
-              $ref: "#/components/schemas/Identifier"
-            name:
-              type: string
+        groupId:
+          $ref: "#/components/schemas/Identifier"
       required:
         - id
         - name
-        - group
+        - groupId
       additionalProperties: false
 
     UserUpdateRequest:

--- a/datameta/api/users.py
+++ b/datameta/api/users.py
@@ -43,7 +43,7 @@ class UserResponseElement(DataHolderBase):
     """Class for User Update Request communication to OpenApi"""
     id: dict
     name: str  # why is this name when it is called fullname in the db?
-    group: dict
+    group_id: dict
     group_admin: Optional[bool] = None
     site_admin: Optional[bool] = None
     site_read: Optional[bool] = None
@@ -61,7 +61,7 @@ class UserResponseElement(DataHolderBase):
                 "email": target_user.email
             })
 
-        return cls(id=get_identifier(target_user), name=target_user.fullname, group=get_identifier(target_user.group), **restricted_fields)
+        return cls(id=get_identifier(target_user), name=target_user.fullname, group_id=get_identifier(target_user.group), **restricted_fields)
 
 
 @dataclass


### PR DESCRIPTION
This PR fixes the following issues:

* `GET:/users/{id}` response violates API specification
* `GET:/users/{id}` response element `group` should be named `groupId` to be consistent with other non-self identifier response attributes