### PR TITLE
Tests portability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ development_notb.ini
 _build*
 docs/make.bat
 docs/Makefile
+.vscode

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -38,9 +38,9 @@ class BaseIntegrationTest(unittest.TestCase):
         # create database from scratch:
         if database_exists(db_url):
             drop_database(db_url)
-        
+
         # handling encoding error
-        # (psycopg2.errors.InvalidParameterValue) new encoding (UTF8) 
+        # (psycopg2.errors.InvalidParameterValue) new encoding (UTF8)
         # is incompatible with the encoding of the template database (SQL_ASCII)
         try:
             create_database(db_url, template="template1", encoding="utf8")

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -6,7 +6,7 @@ import tempfile
 
 import transaction
 from sqlalchemy_utils import create_database, drop_database, database_exists
-from sqlalchemy.exc import DataError
+
 from datameta.models import (
     get_engine,
     get_session_factory,
@@ -40,16 +40,7 @@ class BaseIntegrationTest(unittest.TestCase):
             drop_database(db_url)
 
         # handling encoding error
-        # (psycopg2.errors.InvalidParameterValue) new encoding (UTF8)
-        # is incompatible with the encoding of the template database (SQL_ASCII)
-        try:
-            create_database(db_url, template="template1", encoding="utf8")
-        except DataError:
-            pass
-        try:
-            create_database(db_url, template="template1", encoding="SQL_ASCII")
-        except DataError:
-            print('Error while creating database (potentially an encoding problem)')
+        create_database(db_url, template="template0", encoding="utf8")
 
         # get engine and session factory
         self.engine = get_engine(self.settings)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -6,7 +6,7 @@ import tempfile
 
 import transaction
 from sqlalchemy_utils import create_database, drop_database, database_exists
-
+from sqlalchemy.exc import DataError
 from datameta.models import (
     get_engine,
     get_session_factory,
@@ -38,7 +38,18 @@ class BaseIntegrationTest(unittest.TestCase):
         # create database from scratch:
         if database_exists(db_url):
             drop_database(db_url)
-        create_database(db_url)
+        
+        # handling encoding error
+        # (psycopg2.errors.InvalidParameterValue) new encoding (UTF8) 
+        # is incompatible with the encoding of the template database (SQL_ASCII)
+        try:
+            create_database(db_url, template="template1", encoding="utf8")
+        except DataError:
+            pass
+        try:
+            create_database(db_url, template="template1", encoding="SQL_ASCII")
+        except DataError:
+            print('Error while creating database (potentially an encoding problem)')
 
         # get engine and session factory
         self.engine = get_engine(self.settings)


### PR DESCRIPTION
Fixes an encoding problem while creating a postgresql database for testing.
Probably it is more appropriate to try out the encoding than to switch to the 'template0' by default (maybe its encoding can also change).