### PR TITLE
add legal notice element to default layout and login pages

### DIFF
--- a/datameta/defaults/appsettings.yaml
+++ b/datameta/defaults/appsettings.yaml
@@ -80,6 +80,10 @@ logo_html:
       <a href="/" class="link-bare"><span style="color:#ffca2c">D</span>ata<span style="color:#ffca2c">M</span>eta</a>
     </p>
 
+legal_notice:
+  str_value : |
+      <a href="/" class="link-bare">Legal Notice</a>
+
 user_agreement:
   str_value: ""
     

--- a/datameta/defaults/appsettings.yaml
+++ b/datameta/defaults/appsettings.yaml
@@ -82,7 +82,7 @@ logo_html:
 
 legal_notice:
   str_value : |
-      <a href="/" class="link-bare">Legal Notice</a>
+      <a href="#" class="link-bare">Legal Notice</a>
 
 user_agreement:
   str_value: ""

--- a/datameta/templates/forgot.pt
+++ b/datameta/templates/forgot.pt
@@ -80,7 +80,9 @@
             </div>
         </fieldset>
     </form>
-
+    <p>
+    <span tal:replace="structure legal_notice"></span>
+    </p>
     <script src="${request.static_url('datameta:static/js/forgot.js')}"></script>
 </main>
 </metal:block>

--- a/datameta/templates/forgot.pt
+++ b/datameta/templates/forgot.pt
@@ -80,7 +80,7 @@
             </div>
         </fieldset>
     </form>
-    <p>
+    <p class="mt-2">
     <span tal:replace="structure legal_notice"></span>
     </p>
     <script src="${request.static_url('datameta:static/js/forgot.js')}"></script>

--- a/datameta/templates/layout.pt
+++ b/datameta/templates/layout.pt
@@ -131,7 +131,7 @@
                 </div>
             </div>
             <div class="container mb-1" style="font-size:7pt">
-                <span>DataMeta Version </span><span id="datameta_version"></span><span> - API Version </span><span id="datameta_api_version"></span>
+                <span>DataMeta Version </span><span id="datameta_version"></span><span> - API Version </span><span id="datameta_api_version"></span><span> - </span><span tal:replace="structure legal_notice"></span>
                 <span class="text-danger" tal:condition="request.registry.settings.get('datameta.demo_mode') in [True, 'true', 'True']">
                     - [DEMO MODE]
                 </span>

--- a/datameta/templates/login.pt
+++ b/datameta/templates/login.pt
@@ -72,5 +72,8 @@
     <p class="mt-2">
     <a href="/forgot">Forgot password?</a>
     </p>
+    <p>
+    <span tal:replace="structure legal_notice"></span>
+    </p>
 </main>
 </metal:block>

--- a/datameta/templates/login.pt
+++ b/datameta/templates/login.pt
@@ -72,7 +72,7 @@
     <p class="mt-2">
     <a href="/forgot">Forgot password?</a>
     </p>
-    <p>
+    <p class="mt-2">
     <span tal:replace="structure legal_notice"></span>
     </p>
 </main>

--- a/datameta/templates/register.pt
+++ b/datameta/templates/register.pt
@@ -131,7 +131,9 @@
                 </div>
             </fieldset>
 	</form>
-
+	<p>
+		<span tal:replace="structure legal_notice"></span>
+	</p>
 	<script type="text/javascript" charset="utf8" src="${request.static_url('datameta:static/js/register.js')}"></script>
 </main>
 </metal:block>

--- a/datameta/templates/register.pt
+++ b/datameta/templates/register.pt
@@ -131,8 +131,8 @@
                 </div>
             </fieldset>
 	</form>
-	<p>
-		<span tal:replace="structure legal_notice"></span>
+	<p class="mt-2">
+	<span tal:replace="structure legal_notice"></span>
 	</p>
 	<script type="text/javascript" charset="utf8" src="${request.static_url('datameta:static/js/register.js')}"></script>
 </main>

--- a/datameta/templates/settfa.pt
+++ b/datameta/templates/settfa.pt
@@ -108,11 +108,11 @@
                         <button class="w-100 btn  btn-warning" type="submit" name="tf_form.submitted">Continue</button>
                     </div>
                 </form>
-                <p>
-		        <span tal:replace="structure legal_notice"></span>
-	            </p>
             </div>
         </div>
+        <p class="mt-2">
+        <span tal:replace="structure legal_notice"></span>
+        </p>
         <script type="module" src="${request.static_url('datameta:static/js/settfa.js')}"></script>
     </div>
 </main>

--- a/datameta/templates/settfa.pt
+++ b/datameta/templates/settfa.pt
@@ -108,9 +108,10 @@
                         <button class="w-100 btn  btn-warning" type="submit" name="tf_form.submitted">Continue</button>
                     </div>
                 </form>
-
+                <p>
+		        <span tal:replace="structure legal_notice"></span>
+	            </p>
             </div>
-
         </div>
         <script type="module" src="${request.static_url('datameta:static/js/settfa.js')}"></script>
     </div>

--- a/datameta/templates/tfa.pt
+++ b/datameta/templates/tfa.pt
@@ -65,10 +65,9 @@
                 <button class="w-100 btn btn-warning" type="submit" name="form.submitted">Sign in with OTP</button>
             </div>
         </div>
-        <p>
-        <span tal:replace="structure legal_notice"></span>
-        </p>
-
     </form>    
+    <p>
+    <span tal:replace="structure legal_notice"></span>
+    </p>
 </main>
 </metal:block>

--- a/datameta/templates/tfa.pt
+++ b/datameta/templates/tfa.pt
@@ -65,6 +65,9 @@
                 <button class="w-100 btn btn-warning" type="submit" name="form.submitted">Sign in with OTP</button>
             </div>
         </div>
+        <p>
+        <span tal:replace="structure legal_notice"></span>
+        </p>
 
     </form>    
 </main>

--- a/datameta/views/default.py
+++ b/datameta/views/default.py
@@ -41,6 +41,7 @@ def add_global(event):
     else:
         event['legal_notice'] = appsetting_legal_notice
 
+
 @view_config(route_name='root')
 def root_view(request):
     security.revalidate_user_or_login(request)

--- a/datameta/views/default.py
+++ b/datameta/views/default.py
@@ -26,13 +26,20 @@ log = logging.getLogger(__name__)
 
 @subscriber(BeforeRender)
 def add_global(event):
-    appsetting = settings.get_setting(event['request'].dbsession, "logo_html")
-    if appsetting is None:
+    appsetting_logo_html = settings.get_setting(event['request'].dbsession, "logo_html")
+    appsetting_legal_notice = settings.get_setting(event['request'].dbsession, "legal_notice")
+
+    if appsetting_logo_html is None:
         event['logo_html'] = ''
         log.error("Missing application settings 'logo_html'")
     else:
-        event['logo_html'] = appsetting
+        event['logo_html'] = appsetting_logo_html
 
+    if appsetting_legal_notice is None:
+        event['legal_notice'] = ''
+        log.error("Missing application settings 'legal_notice'")
+    else:
+        event['legal_notice'] = appsetting_legal_notice
 
 @view_config(route_name='root')
 def root_view(request):

--- a/datameta/views/default.py
+++ b/datameta/views/default.py
@@ -26,20 +26,16 @@ log = logging.getLogger(__name__)
 
 @subscriber(BeforeRender)
 def add_global(event):
-    appsetting_logo_html = settings.get_setting(event['request'].dbsession, "logo_html")
-    appsetting_legal_notice = settings.get_setting(event['request'].dbsession, "legal_notice")
+    def add_appsetting_with_default(appsetting_name: str, default: str) -> None:
+        appsetting = settings.get_setting(event['request'].dbsession, appsetting_name)
+        if appsetting is None:
+            event[appsetting_name] = default
+            log.error(f"Missing application settings {appsetting_name}")
+        else:
+            event[appsetting_name] = appsetting
 
-    if appsetting_logo_html is None:
-        event['logo_html'] = ''
-        log.error("Missing application settings 'logo_html'")
-    else:
-        event['logo_html'] = appsetting_logo_html
-
-    if appsetting_legal_notice is None:
-        event['legal_notice'] = ''
-        log.error("Missing application settings 'legal_notice'")
-    else:
-        event['legal_notice'] = appsetting_legal_notice
+    add_appsetting_with_default("logo_html", "")
+    add_appsetting_with_default("legal_notice", "")
 
 
 @view_config(route_name='root')


### PR DESCRIPTION
This PR adds a legal notice element.
Element is derived from appsettings like the `logo_html` element.

Element is positioned in the footer of the default page:
![legal_notice_1](https://user-images.githubusercontent.com/87362681/207860559-4b319c27-daca-4306-bab2-04c4792cefc0.PNG)

Element is positioned below the last button for login related pages (login, register, forgot password, tfa and set tfa pages), e.g.:
![legal_notice_2](https://user-images.githubusercontent.com/87362681/207860563-cb12f231-c76f-4fcc-9aa8-5c0d3a9857f8.PNG)
