### PR TITLE
suggestion for delete metadataset endpoint

### DIFF
--- a/datameta/api/__init__.py
+++ b/datameta/api/__init__.py
@@ -53,6 +53,7 @@ def includeme(config: Configurator) -> None:
     config.add_route("metadata_id", base_url + "/metadata/{id}")
     config.add_route("metadatasets", base_url + "/metadatasets")
     config.add_route("metadatasets_id", base_url + "/metadatasets/{id}")
+    config.add_route("metadatasets_submitted_id", base_url + "/metadatasets/submitted/{id}")
     config.add_route("appsettings", base_url + "/appsettings")
     config.add_route("appsettings_id", base_url + "/appsettings/{id}")
     config.add_route("files", base_url + "/files")

--- a/datameta/api/metadatasets_submitted.py
+++ b/datameta/api/metadatasets_submitted.py
@@ -1,0 +1,114 @@
+# Copyright 2021 Universität Tübingen, DKFZ and EMBL for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from dataclasses import dataclass
+from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound, HTTPNoContent, HTTPInternalServerError
+from pyramid.view import view_config
+from pyramid.request import Request
+from typing import List
+from ..models import MetaDataSet, MetaDatumRecord
+from ..security import authz
+from ..resource import resource_by_id
+from . import DataHolderBase
+from .. import errors
+from ..storage import rm
+
+log = logging.getLogger(__name__)
+
+"""
+"""
+
+
+@dataclass
+class MetaDataSetSubmittedDeleteBase(DataHolderBase):
+    """Base class for File communication to OpenApi"""
+    id: str
+
+
+@dataclass
+class  MetaDataSetSubmittedDeleteResponse(MetaDataSetSubmittedDeleteBase):
+    """"""
+    pass
+
+
+@view_config(
+    route_name="metadatasets_submitted_id",
+    renderer='json',
+    request_method="DELETE",
+    openapi=True
+)
+def delete_metadataset(request: Request) -> HTTPNoContent:
+    auth_user = authz.revalidate_user(request)
+    db_session = request.dbsession
+    metadataset_id = request.matchdict['id']
+    target_metadataset = resource_by_id(db_session, MetaDataSet, metadataset_id)
+
+    #
+    # Checks
+    #
+
+    # Authorization
+    # 401
+    if not authz.delete_submitted_metadataset(auth_user):
+        raise HTTPForbidden()
+
+    # Metadataset exists
+    # 404
+    if not target_metadataset:
+        raise HTTPNotFound()
+
+    # Only operate on submitted metadatasets
+    # 403
+    if not target_metadataset.submission:
+        raise errors.get_not_modifiable_error()
+
+    # Get files
+    target_metadatarecords_files: List[MetaDatumRecord] = [
+        metadatum_record
+        for metadatum_record in target_metadataset.metadatumrecords
+        if metadatum_record.metadatum.isfile
+    ]
+
+    #
+    # Delete the files
+    #
+    if target_metadatarecords_files:
+        for metadatum_record in target_metadatarecords_files:
+            try:
+                rm(request=request, file_id=metadatum_record.file_id)
+            except Exception as e:
+                raise HTTPInternalServerError(json_body={'error': str(e)})
+
+    #
+    # Delete the metadataset
+    #
+
+    db_session.delete(target_metadataset)
+
+    #
+    # Submission has no other metadatasets
+    #
+
+    # not implemented yet
+
+    #
+    # Service executions?
+    #
+
+    # not implemented yet
+
+    return MetaDataSetSubmittedDeleteResponse(
+        metadataset_id=metadataset_id,
+    )

--- a/datameta/api/metadatasets_submitted.py
+++ b/datameta/api/metadatasets_submitted.py
@@ -43,7 +43,7 @@ class MetaDataSetSubmittedDeleteBase(DataHolderBase):
 @dataclass
 class  MetaDataSetSubmittedDeleteResponse(MetaDataSetSubmittedDeleteBase):
     """Response class for MetaDataSetSubmittedDelete API response bodies"""
-    file_ids: List[str] = None
+    file_ids: List[str]
 
 
 @view_config(

--- a/datameta/api/metadatasets_submitted.py
+++ b/datameta/api/metadatasets_submitted.py
@@ -14,18 +14,19 @@
 
 import logging
 from dataclasses import dataclass
-from pyramid.httpexceptions import HTTPNotFound, HTTPInternalServerError, HTTPUnauthorized
-from pyramid.view import view_config
-from pyramid.request import Request
 from typing import List
-from ..models import MetaDataSet, MetaDatumRecord
-from .. import security
-from ..security import authz
-from ..resource import resource_by_id, get_identifier
-from . import DataHolderBase
-from .. import errors
-from ..storage import rm
 
+from pyramid.httpexceptions import (HTTPInternalServerError, HTTPNotFound,
+                                    HTTPUnauthorized)
+from pyramid.request import Request
+from pyramid.view import view_config
+
+from .. import errors, security
+from ..models import MetaDataSet, MetaDatumRecord
+from ..resource import get_identifier, resource_by_id
+from ..security import authz
+from ..storage import rm
+from . import DataHolderBase
 
 log = logging.getLogger(__name__)
 

--- a/datameta/api/metadatasets_submitted.py
+++ b/datameta/api/metadatasets_submitted.py
@@ -92,6 +92,9 @@ def delete_submitted_metadataset(request: Request) -> MetaDataSetSubmittedDelete
                 log.info("Deleting file.", extra={"file_site_id": metadatum_record.file.site_id, "user_site_id": auth_user.site_id})
                 rm(request=request, storage_path=metadatum_record.file.storage_uri)
                 db_session.delete(metadatum_record.file)
+            except FileNotFoundError as e:
+                log.warning("File not found in storage. Skipping deletion.", extra={"file_site_id": metadatum_record.file.site_id, "user_site_id": auth_user.site_id})
+                raise HTTPInternalServerError(json_body={'error': str(e)})
             except Exception as e:
                 raise HTTPInternalServerError(json_body={'error': str(e)})
 

--- a/datameta/api/metadatasets_submitted.py
+++ b/datameta/api/metadatasets_submitted.py
@@ -109,6 +109,8 @@ def delete_submitted_metadataset(request: Request) -> MetaDataSetSubmittedDelete
     # TODO: Submission has no other metadatasets
     #
 
+    db_session.commit()
+
     return MetaDataSetSubmittedDeleteResponse(
         metadataset_id=get_identifier(target_metadataset),
         file_ids=target_metadatarecords_files_ids,

--- a/datameta/api/openapi.yaml
+++ b/datameta/api/openapi.yaml
@@ -2016,6 +2016,15 @@ components:
         - value
       additionalProperties: false
 
+    MetaDataSetSubmittedDeleteResponse:
+      type: object
+      properties:
+        metadataset_id:
+          type: string
+      required:
+        - metadataset_id
+      additionalProperties: false
+
     Identifier:
       type: object
       properties:

--- a/datameta/api/openapi.yaml
+++ b/datameta/api/openapi.yaml
@@ -699,6 +699,38 @@ paths:
         '500':
           description: Internal Server Error
 
+  /metadatasets/submitted/{id}:
+    delete:
+      summary: Delete submitted metadataset
+      description: >-
+        Delete submitted metadataset.
+        Only allowed for site admins.
+      tags:
+        - Metadata
+      operationId: DeleteSubmittedMetadataSet
+      parameters:
+        - name: id
+          in: path
+          description: ID of the Metadataset
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Deletion successful
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+        "404":
+          description: The specified metadataset does not exist.
+        '500':
+          description: Internal Server Error
+
   /service-execution/{serviceId}/{metadatasetId}:
     post:
       summary: Endpoint to store the result of a service execution for a single metadataset
@@ -2028,46 +2060,3 @@ components:
       type: array
       items:
        $ref: "#/components/schemas/Error"
-
-#
-#
-#
-
-/evil/metadatasets/{id}:
-    delete:
-      summary: Delete Submitted Metadataset
-      description: >-
-        Delete submitted Metadataset.
-        Only allowed for site admins.
-        Calls function which removes files which are associated with the Metadataset from storage.
-      tags:
-        - Metadata
-      operationId: DeleteSubmittedMetadataSet
-      parameters:
-        - name: id
-          in: path
-          description: ID of the Metadataset
-          required: true
-          schema:
-            type: string
-      responses:
-        '204':
-          description: Deletion successful
-        '401':
-          description: Unauthorized
-        '403':
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-        "404":
-          description: The specified metadataset does not exist.
-        '400':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-        '500':
-          description: Internal Server Error

--- a/datameta/api/openapi.yaml
+++ b/datameta/api/openapi.yaml
@@ -2028,3 +2028,46 @@ components:
       type: array
       items:
        $ref: "#/components/schemas/Error"
+
+#
+#
+#
+
+/evil/metadatasets/{id}:
+    delete:
+      summary: Delete Submitted Metadataset
+      description: >-
+        Delete submitted Metadataset.
+        Only allowed for site admins.
+        Calls function which removes files which are associated with the Metadataset from storage.
+      tags:
+        - Metadata
+      operationId: DeleteSubmittedMetadataSet
+      parameters:
+        - name: id
+          in: path
+          description: ID of the Metadataset
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Deletion successful
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+        "404":
+          description: The specified metadataset does not exist.
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+        '500':
+          description: Internal Server Error

--- a/datameta/api/openapi.yaml
+++ b/datameta/api/openapi.yaml
@@ -716,8 +716,12 @@ paths:
           schema:
             type: string
       responses:
-        '204':
+        '200':
           description: Deletion successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetaDataSetSubmittedDeleteResponse"
         '401':
           description: Unauthorized
         '403':
@@ -726,7 +730,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
-        "404":
+        '404':
           description: The specified metadataset does not exist.
         '500':
           description: Internal Server Error
@@ -2019,10 +2023,15 @@ components:
     MetaDataSetSubmittedDeleteResponse:
       type: object
       properties:
-        metadataset_id:
-          type: string
+        metadatasetId:
+          $ref: "#/components/schemas/Identifier"
+        fileIds:
+          type: array
+          items:
+            $ref: "#/components/schemas/Identifier"
+          nullable: true
       required:
-        - metadataset_id
+        - metadatasetId
       additionalProperties: false
 
     Identifier:

--- a/datameta/models/db.py
+++ b/datameta/models/db.py
@@ -178,6 +178,7 @@ class File(Base):
     filesize         = Column(BigInteger, nullable=True)
     user_id          = Column(Integer, ForeignKey('users.id'), nullable=False)
     upload_expires   = Column(DateTime, nullable=True)
+    metadatumrecord_id          = Column(Integer, ForeignKey('metadatumrecords.id'), nullable=True)
     # Relationships
     metadatumrecord  = relationship('MetaDatumRecord', back_populates='file', uselist=False)
     user             = relationship('User', back_populates='files')
@@ -236,7 +237,7 @@ class MetaDatumRecord(Base):
     uuid             = Column(UUID(as_uuid=True), unique=True, default=uuid.uuid4, nullable=False)
     metadatum_id     = Column(Integer, ForeignKey('metadata.id'), nullable=False)
     metadataset_id   = Column(Integer, ForeignKey('metadatasets.id'), nullable=False)
-    file_id          = Column(Integer, ForeignKey('files.id'), nullable=True)
+#    file_id          = Column(Integer, ForeignKey('files.id'), nullable=True)
     value            = Column(Text, nullable=True)
     # Relationships
     metadatum        = relationship('MetaDatum', back_populates='metadatumrecords')

--- a/datameta/models/db.py
+++ b/datameta/models/db.py
@@ -178,7 +178,7 @@ class File(Base):
     filesize         = Column(BigInteger, nullable=True)
     user_id          = Column(Integer, ForeignKey('users.id'), nullable=False)
     upload_expires   = Column(DateTime, nullable=True)
-    metadatumrecord_id          = Column(Integer, ForeignKey('metadatumrecords.id'), nullable=True)
+#    metadatumrecord_id          = Column(Integer, ForeignKey('metadatumrecords.id'), nullable=True)
     # Relationships
     metadatumrecord  = relationship('MetaDatumRecord', back_populates='file', uselist=False)
     user             = relationship('User', back_populates='files')
@@ -237,12 +237,12 @@ class MetaDatumRecord(Base):
     uuid             = Column(UUID(as_uuid=True), unique=True, default=uuid.uuid4, nullable=False)
     metadatum_id     = Column(Integer, ForeignKey('metadata.id'), nullable=False)
     metadataset_id   = Column(Integer, ForeignKey('metadatasets.id'), nullable=False)
-#    file_id          = Column(Integer, ForeignKey('files.id'), nullable=True)
+    file_id          = Column(Integer, ForeignKey('files.id'), nullable=True)
     value            = Column(Text, nullable=True)
     # Relationships
     metadatum        = relationship('MetaDatum', back_populates='metadatumrecords')
     metadataset      = relationship('MetaDataSet', back_populates='metadatumrecords')
-    file             = relationship('File', back_populates='metadatumrecord', cascade="all, delete, delete-orphan")
+    file             = relationship('File', back_populates='metadatumrecord')
 
 
 class MetaDataSet(Base):
@@ -261,7 +261,7 @@ class MetaDataSet(Base):
     submission           = relationship('Submission', back_populates='metadatasets')
     metadatumrecords     = relationship('MetaDatumRecord', back_populates='metadataset', cascade="all, delete, delete-orphan")
     replaces             = relationship('MetaDataSet', backref=backref('replaced_by', remote_side=[id]))
-    service_executions   = relationship('ServiceExecution', back_populates = 'metadataset')
+    service_executions   = relationship('ServiceExecution', back_populates = 'metadataset', cascade="all, delete, delete-orphan")
 
 
 class ApplicationSetting(Base):

--- a/datameta/models/db.py
+++ b/datameta/models/db.py
@@ -258,7 +258,7 @@ class MetaDataSet(Base):
     # Relationships
     user                 = relationship('User', back_populates='metadatasets')
     submission           = relationship('Submission', back_populates='metadatasets')
-    metadatumrecords     = relationship('MetaDatumRecord', back_populates='metadataset')
+    metadatumrecords     = relationship('MetaDatumRecord', back_populates='metadataset', cascade="all, delete, delete-orphan")
     replaces             = relationship('MetaDataSet', backref=backref('replaced_by', remote_side=[id]))
     service_executions   = relationship('ServiceExecution', back_populates = 'metadataset')
 

--- a/datameta/models/db.py
+++ b/datameta/models/db.py
@@ -241,7 +241,7 @@ class MetaDatumRecord(Base):
     # Relationships
     metadatum        = relationship('MetaDatum', back_populates='metadatumrecords')
     metadataset      = relationship('MetaDataSet', back_populates='metadatumrecords')
-    file             = relationship('File', back_populates='metadatumrecord')
+    file             = relationship('File', back_populates='metadatumrecord', cascade="all, delete, delete-orphan")
 
 
 class MetaDataSet(Base):

--- a/datameta/security/authz.py
+++ b/datameta/security/authz.py
@@ -157,6 +157,10 @@ def update_user_siteread(user):
     return user.site_admin
 
 
+def delete_submitted_metadataset(user):
+    return user.site_admin
+
+
 def update_user_siteadmin(user, target_user):
     return user.site_admin and not user_is_target(user, target_user)
 

--- a/tests/integration/fixtures/files/test_file_not_exists.txt
+++ b/tests/integration/fixtures/files/test_file_not_exists.txt
@@ -1,0 +1,1 @@
+Maybe I exist here, but not in another file system.

--- a/tests/integration/fixtures/files_metadatasets_submitted_delete.yaml
+++ b/tests/integration/fixtures/files_metadatasets_submitted_delete.yaml
@@ -12,39 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-mset_no_files:
-  class: MetaDataSet
+test_file_not_exists:
+  class: File
   attributes:
-    site_id: mset_no_files
-    records:
-      ID: MDSD01
-      Date: "2021-03-05"
-      ZIP Code: "456"
+    site_id: test_file_not_exists
+    name: test_file_not_exists.txt
+    content_uploaded: True
+    checksum: 04ca5e2ec8a849852560a08bc0a6046e
   references:
     user:
       fixtureset: users
-      name: user_b
-    submission:
-      fixtureset: submissions
-      name: submission_b
-  fixtureOnly:
-    - records
-
-mset_file_not_exists:
-  class: MetaDataSet
-  attributes:
-    site_id: mset_file_not_exists
-    records:
-      ID: MDSD02
-      Date: "2021-03-05"
-      ZIP Code: "456"
-      FileR1: test_file_not_exists.txt
-  references:
-    user:
-      fixtureset: users
-      name: user_b
-    submission:
-      fixtureset: submissions
-      name: submission_b
-  fixtureOnly:
-    - records
+      name: user_a

--- a/tests/integration/fixtures/metadatasets.yaml
+++ b/tests/integration/fixtures/metadatasets.yaml
@@ -98,3 +98,21 @@ mset_b_sexec:
       name: submission_b
   fixtureOnly:
     - records
+
+mset_no_files:
+  class: MetaDataSet
+  attributes:
+    site_id: mset_no_files
+    records:
+      ID: MD05
+      Date: "2021-03-05"
+      ZIP Code: "456"
+  references:
+    user:
+      fixtureset: users
+      name: user_b
+    submission:
+      fixtureset: submissions
+      name: submission_b
+  fixtureOnly:
+    - records

--- a/tests/integration/fixtures/metadatasets.yaml
+++ b/tests/integration/fixtures/metadatasets.yaml
@@ -98,21 +98,3 @@ mset_b_sexec:
       name: submission_b
   fixtureOnly:
     - records
-
-mset_no_files:
-  class: MetaDataSet
-  attributes:
-    site_id: mset_no_files
-    records:
-      ID: MD05
-      Date: "2021-03-05"
-      ZIP Code: "456"
-  references:
-    user:
-      fixtureset: users
-      name: user_b
-    submission:
-      fixtureset: submissions
-      name: submission_b
-  fixtureOnly:
-    - records

--- a/tests/integration/fixtures/metadatasets_submitted_delete.yaml
+++ b/tests/integration/fixtures/metadatasets_submitted_delete.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 Universität Tübingen, DKFZ and EMBL for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mset_no_files:
+  class: MetaDataSet
+  attributes:
+    site_id: mset_no_files
+    records:
+      ID: MD05
+      Date: "2021-03-05"
+      ZIP Code: "456"
+  references:
+    user:
+      fixtureset: users
+      name: user_b
+    submission:
+      fixtureset: submissions
+      name: submission_b
+  fixtureOnly:
+    - records

--- a/tests/integration/test_metadatasets_submitted_id_delete.py
+++ b/tests/integration/test_metadatasets_submitted_id_delete.py
@@ -94,9 +94,9 @@ class TestSubmittedMetaDataSetDelete(BaseIntegrationTest):
 
         # If metadataset was submitted it should be in the list
         if expected_status == 403:
-            assert metadataset_id not in returned_metadataset_ids
+            assert metadataset_id not in returned_metadataset_ids, f"Metadataset {metadataset_id} was found"
         else:
-            assert metadataset_id in returned_metadataset_ids
+            assert metadataset_id in returned_metadataset_ids, f"Metadataset {metadataset_id} was not found"
 
         response_delete = self.testapp.delete(
             url       = f"{base_url}/metadatasets/submitted/{metadataset_id}",
@@ -118,4 +118,4 @@ class TestSubmittedMetaDataSetDelete(BaseIntegrationTest):
             if response_delete.json["fileIds"]:
                 for file in response_delete.json["fileIds"]:
                     fixture_file = self.fixture_manager.get_fixture('files_msets', file["site"])
-                    self.file_exists_in_storage(file["uuid"], fixture_file.checksum)
+                    assert not self.file_exists_in_storage(file["uuid"], fixture_file.checksum), f"File {file['site']} was not deleted"

--- a/tests/integration/test_metadatasets_submitted_id_delete.py
+++ b/tests/integration/test_metadatasets_submitted_id_delete.py
@@ -38,6 +38,7 @@ class TestSubmittedMetaDataSetDelete(BaseIntegrationTest):
         self.fixture_manager.load_fixtureset('files_msets')
         self.fixture_manager.load_fixtureset('submissions')
         self.fixture_manager.load_fixtureset('metadatasets')
+        self.fixture_manager.load_fixtureset('metadatasets_submitted_delete')
         self.fixture_manager.load_fixtureset('serviceexecutions')
         self.fixture_manager.copy_files_to_storage()
         self.fixture_manager.populate_metadatasets()

--- a/tests/integration/test_metadatasets_submitted_id_delete.py
+++ b/tests/integration/test_metadatasets_submitted_id_delete.py
@@ -1,0 +1,121 @@
+# Copyright 2021 Universität Tübingen, DKFZ and EMBL for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import BaseIntegrationTest
+from parameterized import parameterized
+from datameta.api import base_url
+import os
+import hashlib
+
+
+def calc_checksum(file_path: str) -> str:
+    """Calculate the checksum of a file"""
+    with open(file_path, "rb") as file_:
+        byte_content = file_.read()
+        return hashlib.md5(byte_content).hexdigest()
+
+
+class TestGetMetaDataSets(BaseIntegrationTest):
+
+    def setUp(self):
+        super().setUp()
+        self.fixture_manager.load_fixtureset('groups')
+        self.fixture_manager.load_fixtureset('users')
+        self.fixture_manager.load_fixtureset('apikeys')
+        self.fixture_manager.load_fixtureset('services')
+        self.fixture_manager.load_fixtureset('metadata')
+        self.fixture_manager.load_fixtureset('files_msets')
+        self.fixture_manager.load_fixtureset('submissions')
+        self.fixture_manager.load_fixtureset('metadatasets')
+        self.fixture_manager.load_fixtureset('serviceexecutions')
+        self.fixture_manager.copy_files_to_storage()
+        self.fixture_manager.populate_metadatasets()
+
+    def file_exists_in_storage(
+        self,
+        file_uuid: str,
+        file_checksum: str,
+        compare_checksum: bool = True
+    ) -> bool:
+        """Check if a file exists in the storage and optionally compare the checksums"""
+        expected_file_path = os.path.join(
+            self.storage_path,
+            f"{file_uuid}__{file_checksum}"
+        )
+
+        file_exists = os.path.exists(expected_file_path)
+
+        if file_exists and compare_checksum:
+            return file_checksum == calc_checksum(expected_file_path)
+
+        return file_exists
+
+    @parameterized.expand([
+        ('Success', 'admin', 'mset_a' , 200),
+        ('Success', 'admin', 'mset_no_files', 200),
+        ('Success', 'admin', 'mset_a_sexec', 200),
+        ('Success', 'admin', 'mset_b_sexec', 200),
+        ('Not submitted', 'admin', 'mset_b', 403),
+        ('Unauthorized', 'user_a', 'mset_a', 401),
+        ('Unauthorized', 'group_x_admin', 'mset_a', 401),
+        ('Unauthorized', 'user_site_read', 'mset_a', 401),
+        ])
+    def test_query_metadatasets(self,
+            _: str,
+            executing_user: str,
+            metadataset_id: str,
+            expected_status: int,
+            ):
+
+        user = self.fixture_manager.get_fixture('users', executing_user) if executing_user else None
+        auth_headers = self.apikey_auth(user) if user else {}
+
+        # Admin header for GET requests
+        user_admin = self.fixture_manager.get_fixture('users', 'admin')
+        auth_headers_admin = self.apikey_auth(user_admin) if user else {}
+
+        response = self.testapp.get(
+            url       = f"{base_url}/metadatasets",
+            headers   = auth_headers_admin,
+            status    = 200
+        )
+        returned_metadataset_ids = { mset['id']['site'] for mset in response.json }
+
+        # If metadataset was submitted it should be in the list
+        if expected_status == 403:
+            assert metadataset_id not in returned_metadataset_ids
+        else:
+            assert metadataset_id in returned_metadataset_ids
+
+        response_delete = self.testapp.delete(
+            url       = f"{base_url}/metadatasets/submitted/{metadataset_id}",
+            headers   = auth_headers,
+            status    = expected_status
+        )
+
+        # If deletion was successful, check if metadataset and files were deleted
+        if response_delete.status == "success":
+            response = self.testapp.get(
+                url       = f"{base_url}/metadatasets",
+                headers   = auth_headers_admin,
+                status    = 200
+            )
+            returned_mset_ids = { mset['id']['site'] for mset in response.json }
+            assert metadataset_id not in returned_mset_ids
+
+            # Check if files are deleted
+            if response_delete.json["fileIds"]:
+                for file in response_delete.json["fileIds"]:
+                    fixture_file = self.fixture_manager.get_fixture('files_msets', file["site"])
+                    self.file_exists_in_storage(file["uuid"], fixture_file.checksum)

--- a/tests/integration/test_metadatasets_submitted_id_delete.py
+++ b/tests/integration/test_metadatasets_submitted_id_delete.py
@@ -26,7 +26,7 @@ def calc_checksum(file_path: str) -> str:
         return hashlib.md5(byte_content).hexdigest()
 
 
-class TestGetMetaDataSets(BaseIntegrationTest):
+class TestSubmittedMetaDataSetDelete(BaseIntegrationTest):
 
     def setUp(self):
         super().setUp()

--- a/tests/integration/test_metadatasets_submitted_id_delete.py
+++ b/tests/integration/test_metadatasets_submitted_id_delete.py
@@ -71,7 +71,7 @@ class TestGetMetaDataSets(BaseIntegrationTest):
         ('Unauthorized', 'group_x_admin', 'mset_a', 401),
         ('Unauthorized', 'user_site_read', 'mset_a', 401),
         ])
-    def test_query_metadatasets(self,
+    def test_delete_submitted_metadatasets(self,
             _: str,
             executing_user: str,
             metadataset_id: str,


### PR DESCRIPTION
PR to discuss how to implement an **delete** MetaDataSet endpoint

### General

- should only be allowed for site admins

### Implementation: delete MetaDataSets and associated files from storage
- If MetaDataSet has MetaDatumRecords associated with File
   - Remove file from storage and File object from database
- Delete MetaDataSet
  - MetaDatumRecords are deleted via cascade (MetaDataSet is parent of MetaDatumRecord)
  - ServiceExecutions are deleted via cascade (MetaDataSet is parent of ServiceExecution)

### Open questions
-  empty Submission (just one MetaDataSet which was deleted)
- should MetaDatum be a parent of File (conflicts expected)