### PR TITLE
replace hard coded logo with appsetting `logo_html`

### DIFF
--- a/datameta/templates/forgot.pt
+++ b/datameta/templates/forgot.pt
@@ -55,6 +55,7 @@
                             }
 </style>
 <main metal:fill-slot="content" class="form-signin">
+    <div tal:replace="structure logo_html"></div>    
     <div id="alert" class="alert alert-danger collapse" role="alert">
         An unknown error occurred.
     </div>
@@ -63,7 +64,6 @@
             If this email address is registered with us, it will receive a recovery link shortly. Please check your inbox.
         </div>
     </div>
-    <h1 class="h3 mb-3 fw-normal" style="font-family: 'Fira Sans', sans-serif;"><span style="color:#ffca2c">D</span>ata<span style="color:#ffca2c">M</span>eta</h1>
     <form action="#" id="forgotform">
         <fieldset id="forgotfieldset">
             <div class="input-group mb-3">

--- a/datameta/templates/forgot.pt
+++ b/datameta/templates/forgot.pt
@@ -64,7 +64,7 @@
             If this email address is registered with us, it will receive a recovery link shortly. Please check your inbox.
         </div>
     </div>
-    <form action="#" id="forgotform">
+    <form action="#" id="forgotform" class="mt-3">
         <fieldset id="forgotfieldset">
             <div class="input-group mb-3">
                 <span class="input-group-text" id="desc_input_email">


### PR DESCRIPTION
Fix logo on forgot page.

There is still a small problem, even placed at the same position the vertical positioning is not identical

![grafik](https://user-images.githubusercontent.com/87362681/209099322-ac36b77d-c3d5-40f1-8d2d-84558c67269a.png)

![grafik](https://user-images.githubusercontent.com/87362681/209099252-80723cfe-dc70-4678-8fad-7bb5e8cdcc18.png)

